### PR TITLE
Fixed strain tensor

### DIFF
--- a/src/pages/sol/strain.astro
+++ b/src/pages/sol/strain.astro
@@ -154,10 +154,12 @@ Dimensionless [mm/mm, in/in, or %]
 
 <!-- <DisplayEquation equation=" E&nbsp;= \\begin{bmatrix} \\varepsilon_{xx} &amp; \\gamma_{xy} &amp; \\gamma_{xz} \\\\ \\gamma_{yx} &amp; \\varepsilon_{yy} &amp; \\gamma_{yz} \\\\ \\gamma_{zx} &amp;\\gamma_{zy} &amp; \\varepsilon_{zz} \\end{bmatrix} \\" /> -->
 
+The tensor contains:
 
 <Itemize>
     <Item>  Three normal strain components: <InlineEquation equation="\\varepsilon_{xx}, \\varepsilon_{yy}, \\varepsilon_{zz}" /></Item>
     <Item> Six shear strain components: <InlineEquation equation="\\gamma_{xy} =\\gamma_{yx}, \\gamma_{xz}=\\gamma_{zx}, \\gamma_{yz}=\\gamma_{zy}" /></Item>
+    <Item> Note that the tensor shear strain (<InlineEquation equation = "\\varepsilon_{ij}" />) is defined as half of the engineering shear strain (<InlineEquation equation = "\\gamma_{ij}" />). </Item>
 </Itemize>
 
 <p>


### PR DESCRIPTION
Addressing issue #295. The strain tensor section has been updated to include two tensors, one in terms of just varepsilon, and another including gamma terms but with the 1/2 in front. I've also updated all the normal stress terms to say xx, yy, and zz like in the wikipedia reference provided, but please let me know if I should change it back.