### PR TITLE
Update on home button

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -314,7 +314,7 @@ const path = Astro.url.pathname;
             <div class="col d-flex flex-fill px-0">
                 <div class="site_identification">
                     <div class="parent_name hide-empty d-none d-sm-block" data-value="35">
-                        <a href="https://www.refpages.org/" target="_blank" aria-label="The Grainger College of Engineering; Link opens in new tab">
+                        <a href="https://www.refpages.org/" aria-label="The Grainger College of Engineering">
                             <span>Reference Pages</span>
                         </a>
                     </div>


### PR DESCRIPTION
Resolves issue #[326](https://github.com/refpages/mechref/issues/326). 

The refpages home button doesn't make a new tab. The code redirects the current tab to the refpages website. 