### PR TITLE
Update SymPy tutorial link to use .html extension

### DIFF
--- a/src/pages/dyn.astro
+++ b/src/pages/dyn.astro
@@ -98,7 +98,7 @@ import "../../public/static/css/course_home_pages.css"
   <section class="mt-sm-4 mt-2">
     <h3 class="fw-bold w-100">Helpful links:</h3>
     <ul>
-      <li><a href="/dyn/sympy_tutorial">SymPy tutorial</a></li>
+      <li><a href="/dyn/sympy_tutorial.html">SymPy tutorial</a></li>
       <li><a href="/about/reference_pages_tutorial">Reference pages tutorial</a></li>
     </ul>
   </section>


### PR DESCRIPTION
Tom pointed out that this link is broken. I believe it's just missing a `.html` which this PR adds.